### PR TITLE
Error en la traducción de la línea 48

### DIFF
--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -45,7 +45,7 @@ Al acceder al contenido de la sintaxis Razor, preste especial atención a las si
 
 ### <a name="names"></a>Nombres
 
-El nombre de un componente debe empezar por mayúsculas. Por ejemplo, `MyCoolComponent.razor` no es válido, pero `myCoolComponent.razor` sí.
+El nombre de un componente debe empezar por mayúsculas. Por ejemplo, `MyCoolComponent.razor` es válido, pero `myCoolComponent.razor` no.
 
 ### <a name="routing"></a>Enrutamiento
 


### PR DESCRIPTION
En esta la traducción es incorrecta, ya que al español propone lo contrario de la validez de un componente con mayúsculas

Información útil para hacer una sugerencia:
1. Vaya a [Quick Start Localization Style Guides(Guías de estilo de localización de inicio rápido)](https://docs.Microsoft.com/Globalization/Localization/styleguides) para comprobar las **diez reglas más importantes** de la guía de estilo de Microsoft.
2. Vaya a [Portal lingüístico de Microsoft](https://www.Microsoft.com/Language) para comprobar la **traducción normalizada de un término** en todos los productos de Microsoft.
